### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   macos-tests:
     name: macOS Tests (Swift ${{ matrix.swift }})


### PR DESCRIPTION
Potential fix for [https://github.com/vamsii777/DIGIPIN/security/code-scanning/1](https://github.com/vamsii777/DIGIPIN/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow does not perform any write operations, the permissions can be limited to `contents: read`. This block should be added at the root level of the workflow to apply to all jobs, ensuring consistent and minimal permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
