### PR TITLE
Make DIGIPIN Sendable and extend CI matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,15 +12,17 @@ permissions:
 
 jobs:
   macos-tests:
-    name: macOS Tests (Swift ${{ matrix.swift }})
+    name: macOS Tests (${{ matrix.name }})
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - swift: "5.10"
-            xcode: "15.4"
-          - swift: "6.0"
+          - name: "Xcode 16.0"
+            swift: "6.0"
+            xcode: "16.0"
+          - name: "Xcode 16.1"
+            swift: "6.0"
             xcode: "16.1"
     
     steps:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,17 +17,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["6.0"]
+        include:
+          - swift: "5.10"
+            xcode: "15.4"
+          - swift: "6.0"
+            xcode: "16.1"
     
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      
-      - name: Select Xcode for Swift ${{ matrix.swift }}
-        run: |
-          sudo xcode-select -s /Applications/Xcode_16.1.app
-          swift --version
+
+      - name: Select Xcode ${{ matrix.xcode }}
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: ${{ matrix.xcode }}
+
+      - name: Show Swift version
+        run: swift --version
       
       - name: Build
         run: swift build

--- a/Sources/DIGIPIN/DIGIPIN.swift
+++ b/Sources/DIGIPIN/DIGIPIN.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Errors that can occur during DIGIPIN encoding or decoding.
-public enum DIGIPINError: Error, Equatable, CustomStringConvertible {
+public enum DIGIPINError: Error, Equatable, CustomStringConvertible, Sendable {
     /// The provided coordinates are outside the supported bounds for India.
     case outOfBounds
     /// The provided DIGIPIN code is invalid or malformed.
@@ -22,7 +22,7 @@ public enum DIGIPINError: Error, Equatable, CustomStringConvertible {
 }
 
 /// Represents a geographic coordinate (latitude and longitude).
-public struct Coordinate: Equatable, CustomStringConvertible {
+public struct Coordinate: Equatable, CustomStringConvertible, Sendable {
     /// Latitude in decimal degrees (WGS84).
     public let latitude: Double
     /// Longitude in decimal degrees (WGS84).
@@ -43,7 +43,7 @@ public struct Coordinate: Equatable, CustomStringConvertible {
 }
 
 /// DIGIPIN encoder/decoder for India Post's Digital Postal Index Number system.
-public struct DIGIPIN {
+public struct DIGIPIN: Sendable {
     // MARK: - Constants
 
     /// The official 4x4 DIGIPIN grid used at all levels.

--- a/Tests/DIGIPINTests/DIGIPINTests.swift
+++ b/Tests/DIGIPINTests/DIGIPINTests.swift
@@ -185,4 +185,21 @@ final class DIGIPINTests: XCTestCase {
             XCTFail("Third code should fail with invalidDIGIPIN")
         }
     }
+
+    func testDIGIPINCanBeStoredInSendableType() throws {
+        struct LocationService: Sendable {
+            let maxDistanceKm: Double
+            let digipin = DIGIPIN()
+
+            func code(for coordinate: Coordinate) throws -> String {
+                try digipin.generateDIGIPIN(for: coordinate)
+            }
+        }
+
+        let service = LocationService(maxDistanceKm: 5)
+        let coordinate = Coordinate(latitude: 28.622788, longitude: 77.213033)
+
+        XCTAssertEqual(service.maxDistanceKm, 5)
+        XCTAssertEqual(try service.code(for: coordinate), "39J-49L-L8T4")
+    }
 }


### PR DESCRIPTION
This pull request makes `DIGIPIN`, `Coordinate`, and `DIGIPINError` explicitly `Sendable` to improve Swift 6 strict concurrency compatibility. 